### PR TITLE
Redstone pumkin orientation fix

### DIFF
--- a/src/RedstoneListener.java
+++ b/src/RedstoneListener.java
@@ -310,11 +310,13 @@ public class RedstoneListener extends CraftBookDelegateListener
                 && (type == BlockType.PUMPKIN || type == BlockType.JACKOLANTERN)) {
             Boolean useOn = Redstone.testAnyInput(pt);
 
+            int data = CraftBook.getBlockData(pt);
             if (useOn != null && useOn) {
                 CraftBook.setBlockID(pt, BlockType.JACKOLANTERN);
             } else if (useOn != null) {
                 CraftBook.setBlockID(pt, BlockType.PUMPKIN);
             }
+            CraftBook.setBlockData(pt, data);
         // Redstone netherstone
         } else if (redstoneNetherstone
                 && (type == BlockType.NETHERSTONE)) {


### PR DESCRIPTION
Redstone pumkins now keep their orientation when toggled.

Edit: I don't know why the whole file is marked as changed. The changes are in line 313 and 319.
