### PR TITLE
Fixed the bug, that the sign stack is endless (if something fails)

### DIFF
--- a/src/common/com/sk89q/craftbook/MechanicManager.java
+++ b/src/common/com/sk89q/craftbook/MechanicManager.java
@@ -145,7 +145,7 @@ public class MechanicManager {
             }
             
             event.setCancelled(true);
-            block.getWorld().dropItem(block.getLocation(), new ItemStack(Material.SIGN));
+            block.getWorld().dropItem(block.getLocation(), new ItemStack(Material.SIGN, 1));
             block.setTypeId(0);
         }
         


### PR DESCRIPTION
This commit fixes a severe bug, where the user get a endless stack of signs, if the something fails. For example if the user has no permission to create something.

To reproduce this bug, create a bridge without having the permission. Then pick up the sign “stack” and you will see that it is endless.

Fabian
