### PR TITLE
Close books.txt

### DIFF
--- a/src/mechanisms/com/sk89q/craftbook/mech/Bookcase.java
+++ b/src/mechanisms/com/sk89q/craftbook/mech/Bookcase.java
@@ -115,6 +115,7 @@ public class Bookcase extends AbstractMechanic {
                 if (found) {
                     if (data[i] == 10 || data[i] == 13 || i >= len) {
                         if (last != 10 && last != 13) {
+                            file.close();
                             return buffer.toString();
                         }
                     } else {
@@ -128,6 +129,7 @@ public class Bookcase extends AbstractMechanic {
             }
         }
 
+        file.close();
         return null;
     }
     


### PR DESCRIPTION
After a bookcase is right-clicked, books.txt is never closed. Griefers could spam using bookcases until the server is out of file handles, and that would cause bad things.

("Wasn't this part of another pull request?" Yeah, but I figured this would get through much easier by itself, and that pull request was from my fork's master branch and I wanted to be able to commit again without stuff going to that pull request.)
