### PR TITLE
Fixes Redstone Updates - 3-Output IC

### DIFF
--- a/circuits/src/main/java/com/sk89q/craftbook/ic/ICUtil.java
+++ b/circuits/src/main/java/com/sk89q/craftbook/ic/ICUtil.java
@@ -76,7 +76,7 @@ public class ICUtil {
 				// I dont know what the params at the back mean, but the method works perfectly without them.
 				nmsBlock.interact(nmsWorld, block.getX(), block.getY(), block.getZ(), null, 0, 0, 0, 0);
 				return true;
-			} catch (Exception e) {
+			} catch (Throwable e) {
 				// lets catch the exception if the method is not supported
 				block.setData((byte) newData, true);
 				// get the block the lever is attached to:


### PR DESCRIPTION
This fixes the redstone update for all surrounding blocks since it uses the interact method a player would normally trigger.

This will fix all 3 Output ICs and other bugs that have todo with redstone not updating correctly.

// I left the old code in as a Fallback Option if CraftBukkit would change its method signature
