### PR TITLE
Sign Directions Fix

### DIFF
--- a/common/src/main/java/com/sk89q/craftbook/util/SignUtil.java
+++ b/common/src/main/java/com/sk89q/craftbook/util/SignUtil.java
@@ -93,29 +93,29 @@ public class SignUtil {
 	    if (sign.getType() == Material.SIGN_POST) {
 		    switch (sign.getData()) {
 			    case 0x0:
-				    return BlockFace.SOUTH;
+				    return BlockFace.WEST;
 			    case 0x1:
 			    case 0x2:
 			    case 0x3:
-				    return BlockFace.SOUTH_WEST;
+				    return BlockFace.NORTH_WEST;
 			    case 0x4:
-				    return BlockFace.WEST;
+				    return BlockFace.NORTH;
 			    case 0x5:
 			    case 0x6:
 			    case 0x7:
-				    return BlockFace.NORTH_WEST;
+				    return BlockFace.NORTH_EAST;
 			    case 0x8:
-				    return BlockFace.NORTH;
+				    return BlockFace.EAST;
 			    case 0x9:
 			    case 0xA:
 			    case 0xB:
-				    return BlockFace.NORTH_EAST;
+				    return BlockFace.SOUTH_EAST;
 			    case 0xC:
-				    return BlockFace.EAST;
+				    return BlockFace.SOUTH;
 			    case 0xD:
 			    case 0xE:
 			    case 0xF:
-				    return BlockFace.SOUTH_EAST;
+				    return BlockFace.SOUTH_WEST;
 			    default:
 				    return BlockFace.SELF;
 		    }
@@ -123,13 +123,13 @@ public class SignUtil {
 	    else {
 		    switch (sign.getData()) {
 			    case 0x3:
-				    return BlockFace.SOUTH;
-			    case 0x2:
-				    return BlockFace.NORTH;
-			    case 0x4:
 				    return BlockFace.WEST;
-			    case 0x5:
+			    case 0x2:
 				    return BlockFace.EAST;
+			    case 0x4:
+				    return BlockFace.NORTH;
+			    case 0x5:
+				    return BlockFace.SOUTH;
 			    default:
 				    return BlockFace.SELF;
 		    }
@@ -156,29 +156,29 @@ public class SignUtil {
         if (sign.getType() == Material.SIGN_POST) {
             switch (sign.getData()) {
                 case 0x0:
-                    return BlockFace.NORTH;
+                    return BlockFace.EAST;
                 case 0x1:
                 case 0x2:
                 case 0x3:
-                    return BlockFace.NORTH_EAST;
+                    return BlockFace.SOUTH_EAST;
                 case 0x4:
-                    return BlockFace.EAST;
+                    return BlockFace.SOUTH;
                 case 0x5:
                 case 0x6:
                 case 0x7:
-                    return BlockFace.SOUTH_EAST;
+                    return BlockFace.SOUTH_WEST;
                 case 0x8:
-                    return BlockFace.SOUTH;
+                    return BlockFace.WEST;
                 case 0x9:
                 case 0xA:
                 case 0xB:
-                    return BlockFace.SOUTH_WEST;
+                    return BlockFace.NORTH_WEST;
                 case 0xC:
-                    return BlockFace.WEST;
+                    return BlockFace.NORTH;
                 case 0xD:
                 case 0xE:
                 case 0xF:
-                    return BlockFace.NORTH_WEST;
+                    return BlockFace.NORTH_EAST;
                 default:
                     return BlockFace.SELF;
             }
@@ -186,13 +186,13 @@ public class SignUtil {
         else {
             switch (sign.getData()) {
 	            case 0x3:
-		            return BlockFace.NORTH;
+		            return BlockFace.EAST;
                 case 0x2:
-                    return BlockFace.SOUTH;
-                case 0x4:
-                    return BlockFace.EAST;
-                case 0x5:
                     return BlockFace.WEST;
+                case 0x4:
+                    return BlockFace.SOUTH;
+                case 0x5:
+                    return BlockFace.NORTH;
                 default:
                     return BlockFace.SELF;
             }
@@ -238,29 +238,29 @@ public class SignUtil {
 	    if (sign.getType() == Material.SIGN_POST) {
 		    switch (sign.getData()) {
 			    case 0x0:
-				    return BlockFace.EAST;
+				    return BlockFace.SOUTH;
 			    case 0x1:
 			    case 0x2:
 			    case 0x3:
-				    return BlockFace.SOUTH_EAST;
+				    return BlockFace.SOUTH_WEST;
 			    case 0x4:
-				    return BlockFace.SOUTH;
+				    return BlockFace.WEST;
 			    case 0x5:
 			    case 0x6:
 			    case 0x7:
-				    return BlockFace.SOUTH_WEST;
+				    return BlockFace.NORTH_WEST;
 			    case 0x8:
-				    return BlockFace.WEST;
+				    return BlockFace.NORTH;
 			    case 0x9:
 			    case 0xA:
 			    case 0xB:
-				    return BlockFace.NORTH_WEST;
+				    return BlockFace.NORTH_EAST;
 			    case 0xC:
-				    return BlockFace.NORTH;
+				    return BlockFace.EAST;
 			    case 0xD:
 			    case 0xE:
 			    case 0xF:
-				    return BlockFace.NORTH_EAST;
+				    return BlockFace.SOUTH_EAST;
 			    default:
 				    return BlockFace.SELF;
 		    }
@@ -268,13 +268,13 @@ public class SignUtil {
 	    else {
 		    switch (sign.getData()) {
 			    case 0x3:
-				    return BlockFace.EAST;
-			    case 0x2:
-				    return BlockFace.WEST;
-			    case 0x4:
 				    return BlockFace.SOUTH;
-			    case 0x5:
+			    case 0x2:
 				    return BlockFace.NORTH;
+			    case 0x4:
+				    return BlockFace.WEST;
+			    case 0x5:
+				    return BlockFace.EAST;
 			    default:
 				    return BlockFace.SELF;
 		    }
@@ -301,29 +301,29 @@ public class SignUtil {
         if (sign.getType() == Material.SIGN_POST) {
             switch (sign.getData()) {
                 case 0x0:
-                    return BlockFace.WEST;
+                    return BlockFace.NORTH;
                 case 0x1:
                 case 0x2:
                 case 0x3:
-                    return BlockFace.NORTH_WEST;
+                    return BlockFace.NORTH_EAST;
                 case 0x4:
-                    return BlockFace.NORTH;
+                    return BlockFace.EAST;
                 case 0x5:
                 case 0x6:
                 case 0x7:
-                    return BlockFace.NORTH_EAST;
+                    return BlockFace.SOUTH_EAST;
                 case 0x8:
-                    return BlockFace.EAST;
+                    return BlockFace.SOUTH;
                 case 0x9:
                 case 0xA:
                 case 0xB:
-                    return BlockFace.SOUTH_EAST;
+                    return BlockFace.SOUTH_WEST;
                 case 0xC:
-                    return BlockFace.SOUTH;
+                    return BlockFace.WEST;
                 case 0xD:
                 case 0xE:
                 case 0xF:
-                    return BlockFace.SOUTH_WEST;
+                    return BlockFace.NORTH_WEST;
                 default:
                     return BlockFace.SELF;
             }
@@ -331,13 +331,13 @@ public class SignUtil {
         else {
             switch (sign.getData()) {
 	            case 0x3:
-		            return BlockFace.WEST;
+		            return BlockFace.NORTH;
                 case 0x2:
-                    return BlockFace.EAST;
-                case 0x4:
-                    return BlockFace.NORTH;
-                case 0x5:
                     return BlockFace.SOUTH;
+                case 0x4:
+                    return BlockFace.EAST;
+                case 0x5:
+                    return BlockFace.WEST;
                 default:
                     return BlockFace.SELF;
             }


### PR DESCRIPTION
I fixed the return of the wrong direction when checking the left, right, front or back block of a sign post or wall sign.

I dont know if this changed in Minecraft or in Bukkit but I noticed it when using the counter clock since it didnt reset from the left anymore, like it is supposed to (see IC Families).
