### PR TITLE
Dupe fix, teleportation fix, small StringBuilder flavoured nitpick

### DIFF
--- a/circuits/src/main/java/com/sk89q/craftbook/gates/world/SetBlockAboveChest.java
+++ b/circuits/src/main/java/com/sk89q/craftbook/gates/world/SetBlockAboveChest.java
@@ -92,24 +92,23 @@ public class SetBlockAboveChest extends SetBlockAbove {
     public boolean takeFromChest(int x, int y, int z, int id, byte data) {
 
         boolean ret = false;
-        Block bl = BukkitUtil.toSign(getSign()).getBlock().getWorld().getBlockAt(x, y, z);
+        Block bl = BukkitUtil.toSign(getSign()).getWorld().getBlockAt(x, y, z);
         if (bl.getTypeId() == BlockID.CHEST) {
             Chest c = (Chest) bl.getState();
             ItemStack[] is = c.getInventory().getContents();
             for (short i = 0; i < is.length; i++) {
-                if (is[i] == null) {
+                ItemStack stack = is[i];
+                if (stack == null) {
                     continue;
                 }
-                if (is[i].getAmount() > 0 && is[i].getTypeId() == id) {
-                    if (data != -1 && !(is[i].getData().getData() == data)) {
+                if (stack.getAmount() > 0 && stack.getTypeId() == id) {
+                    if (data != -1 && !(stack.getData().getData() == data)) {
                         continue;
                     }
-                    ItemStack stack = is[i];
-                    BukkitUtil.toSign(getSign()).getWorld().dropItemNaturally(new Location(BukkitUtil.toSign(getSign()).getWorld(), x, y, z), stack);
-                    if (is[i].getAmount() == 1) {
+                    if (stack.getAmount() == 1) {
                         is[i] = new ItemStack(0, 0);
                     } else {
-                        is[i].setAmount(is[i].getAmount() - 1);
+                        stack.setAmount(stack.getAmount() - 1);
                     }
                     ret = true;
                     break;

--- a/circuits/src/main/java/com/sk89q/craftbook/gates/world/SetBlockBelowChest.java
+++ b/circuits/src/main/java/com/sk89q/craftbook/gates/world/SetBlockBelowChest.java
@@ -3,6 +3,7 @@ package com.sk89q.craftbook.gates.world;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Server;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.inventory.ItemStack;
@@ -93,25 +94,24 @@ public class SetBlockBelowChest extends AbstractIC {
     public boolean takeFromChest(int x, int y, int z, int id, byte data) {
 
         boolean ret = false;
-        Block bl = BukkitUtil.toSign(getSign()).getBlock().getWorld().getBlockAt(x, y, z);
+        Block bl = BukkitUtil.toSign(getSign()).getWorld().getBlockAt(x, y, z);
         if (bl.getTypeId() == BlockID.CHEST) {
             Chest c = (Chest) bl.getState();
             ItemStack[] is = c.getInventory().getContents();
             for (int i = 0; i < is.length; i++) {
-                if (is[i] == null) {
+                final ItemStack stack = is[i];
+                if (stack == null) {
                     continue;
                 }
-                if (is[i].getAmount() > 0 && is[i].getTypeId() == id) {
+                if (stack.getAmount() > 0 && stack.getTypeId() == id) {
                     if (data != -1)
-                        if (!(is[i].getData().getData() == data)) {
+                        if (!(stack.getData().getData() == data)) {
                             continue;
                         }
-                    ItemStack stack = is[i];
-                    BukkitUtil.toSign(getSign()).getWorld().dropItemNaturally(new Location(BukkitUtil.toSign(getSign()).getWorld(), x, y, z), stack);
-                    if (is[i].getAmount() == 1) {
+                    if (stack.getAmount() == 1) {
                         is[i] = new ItemStack(0, 0);
                     } else {
-                        is[i].setAmount(is[i].getAmount() - 1);
+                        stack.setAmount(stack.getAmount() - 1);
                     }
                     ret = true;
                     break;

--- a/circuits/src/main/java/com/sk89q/jinglenote/MidiJingleSequencer.java
+++ b/circuits/src/main/java/com/sk89q/jinglenote/MidiJingleSequencer.java
@@ -131,7 +131,7 @@ public class MidiJingleSequencer implements JingleSequencer {
                 Thread.sleep(1000);
             }
 
-            if (sequencer.isOpen()) {
+            if (sequencer.isRunning()) {
                 sequencer.stop();
             }
         } catch (MidiUnavailableException e) {

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/CookingPot.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/CookingPot.java
@@ -43,9 +43,6 @@ public class CookingPot extends PersistentMechanic implements SelfTriggeringMech
 
     /**
      * Construct a cooking pot for a location.
-     *
-     * @param pt
-     * @param plugin
      */
     public CookingPot(BlockWorldVector pt, MechanismsPlugin plugin) {
 
@@ -132,7 +129,7 @@ public class CookingPot extends PersistentMechanic implements SelfTriggeringMech
             try {
                 lastTick = Integer.parseInt(sign.getLine(2));
             } catch (Exception e) {
-                sign.setLine(2, lastTick + "");
+                sign.setLine(2, String.valueOf(lastTick));
                 sign.update();
             }
             oldTick = lastTick;
@@ -168,7 +165,7 @@ public class CookingPot extends PersistentMechanic implements SelfTriggeringMech
                 }
             }
             if (lastTick != oldTick) {
-                sign.setLine(2, lastTick + "");
+                sign.setLine(2, String.valueOf(lastTick));
                 sign.update();
             }
         }
@@ -230,7 +227,7 @@ public class CookingPot extends PersistentMechanic implements SelfTriggeringMech
         if (amount < 1 && !plugin.getLocalConfiguration().cookingPotSettings.requiresfuel) {
             amount = 1;
         }
-        sign.setLine(3, amount + "");
+        sign.setLine(3, String.valueOf(amount));
         sign.update();
     }
 
@@ -246,10 +243,7 @@ public class CookingPot extends PersistentMechanic implements SelfTriggeringMech
 
     public int getMultiplier(Sign sign) {
 
-        int multiplier = 1;
-        if (plugin.getLocalConfiguration().cookingPotSettings.requiresfuel) {
-            multiplier = 0;
-        }
+        int multiplier;
         try {
             multiplier = Integer.parseInt(sign.getLine(3));
         } catch (Exception e) {

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/Teleporter.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/Teleporter.java
@@ -23,6 +23,8 @@ import com.sk89q.worldedit.blocks.BlockID;
 import com.sk89q.worldedit.blocks.BlockType;
 import com.sk89q.worldedit.bukkit.BukkitUtil;
 
+import java.util.regex.Pattern;
+
 /**
  * Teleporter Mechanism. Based off Elevator
  *
@@ -197,10 +199,10 @@ public class Teleporter extends AbstractMechanic {
 
         // Teleport!
         Location subspaceRift = player.getPosition();
-        subspaceRift = subspaceRift.setPosition(new Vector(floor.getX(), floor.getY() + 1, floor.getZ()));
+        subspaceRift = subspaceRift.setPosition(new Vector(floor.getX() + 0.5, floor.getY() + 1, floor.getZ() + 0.5));
         if (player.isInsideVehicle()) {
             subspaceRift = player.getVehicle().getLocation();
-            subspaceRift = subspaceRift.setPosition(new Vector(floor.getX(), floor.getY() + 2, floor.getZ()));
+            subspaceRift = subspaceRift.setPosition(new Vector(floor.getX() + 0.5, floor.getY() + 2, floor.getZ() + 0.5));
             player.getVehicle().teleport(subspaceRift);
         }
         if (plugin.getLocalConfiguration().teleporterSettings.maxrange > 0 && subspaceRift.getPosition().distanceSq


### PR DESCRIPTION
Dupe fix - don't drop the item from the chest as well as placing it ingame
Teleportation fix - teleport to the center of the block with the sign on it
Nitpick - in CookingPot, replacing +"" with String.valueOf, removing useless javadoc @param, and removing unused assignment to "multiplier"
IllegalStateException fix on song end for mc1270

I would also fix potato boiling but sk89q's ItemID doesn't have it.
