### PR TITLE
Electric boogaloo

### DIFF
--- a/common/src/main/java/com/sk89q/craftbook/MechanicManager.java
+++ b/common/src/main/java/com/sk89q/craftbook/MechanicManager.java
@@ -574,6 +574,7 @@ public class MechanicManager {
         } catch (Throwable t) { // Mechanic failed to unload for some reason
             logger.log(Level.WARNING, "CraftBook mechanic: Failed to unload " + mechanic.getClass().getCanonicalName
                     (), t);
+            t.printStackTrace();
         }
 
         synchronized (this) {
@@ -605,6 +606,7 @@ public class MechanicManager {
         } catch (Throwable t) { // Mechanic failed to unload for some reason
             logger.log(Level.WARNING, "CraftBook mechanic: Failed to unload " + mechanic.getClass().getCanonicalName
                     (), t);
+            t.printStackTrace();
         }
 
         synchronized (this) {
@@ -634,9 +636,10 @@ public class MechanicManager {
             if (mechanic.isActive()) {
                 try {
                     mechanic.think();
-                } catch (Throwable t) { // Mechanic failed to unload for some reason
+                } catch (Throwable t) { // Mechanic failed to think for some reason
                     logger.log(Level.WARNING, "CraftBook mechanic: Failed to think for " + mechanic.getClass()
                             .getCanonicalName(), t);
+                    t.printStackTrace();
                 }
             } else {
                 unload(mechanic);

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/XPStorer.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/XPStorer.java
@@ -52,14 +52,14 @@ public class XPStorer extends AbstractMechanic {
     public void onRightClick(PlayerInteractEvent event) {
 
         if (!plugin.wrap(event.getPlayer()).hasPermission("craftbook.mech.xpstore.use")) return;
-        if(event.getPlayer().isSneaking() || event.getPlayer().getTotalExperience() < 15) {
+        if (event.getPlayer().isSneaking() || event.getPlayer().getTotalExperience() < 15) {
             return;
         }
 
-        event.getClickedBlock().getWorld().dropItemNaturally(event.getClickedBlock().getLocation(), new ItemStack(ItemID.BOTTLE_O_ENCHANTING, (int) Math.floor(event.getPlayer().getTotalExperience() / 15)));
+        event.getClickedBlock().getWorld().dropItemNaturally(event.getClickedBlock().getLocation(), new ItemStack(ItemID.BOTTLE_O_ENCHANTING, event.getPlayer().getTotalExperience() / 15));
 
         event.getPlayer().setLevel(0);
-        event.getPlayer().setTotalExperience(0);
+        event.getPlayer().setExp(0);
 
         event.setCancelled(true);
     }

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/cauldron/ImprovedCauldron.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/cauldron/ImprovedCauldron.java
@@ -159,16 +159,16 @@ public class ImprovedCauldron extends AbstractMechanic implements Listener {
         if (id == 269) {
             mutliplier = 1;
         }
-        if (id == 273) {
+        else if (id == 273) {
             mutliplier = 2;
         }
-        if (id == 256) {
+        else if (id == 256) {
             mutliplier = 3;
         }
-        if (id == 277) {
+        else if (id == 277) {
             mutliplier = 4;
         }
-        if (id == 284) {
+        else if (id == 284) {
             mutliplier = 5;
         }
         mutliplier += item.getEnchantmentLevel(Enchantment.DIG_SPEED);

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/Cannon.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/Cannon.java
@@ -2,6 +2,7 @@ package com.sk89q.craftbook.mech.dispenser;
 
 import com.sk89q.worldedit.blocks.BlockID;
 import com.sk89q.worldedit.blocks.ItemID;
+import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.EntityType;
@@ -30,11 +31,10 @@ public class Cannon extends Recipe {
     @Override
     public boolean doAction(Dispenser dis, ItemStack item, Vector velocity, BlockDispenseEvent event) {
 
-        MaterialData d = dis.getBlock().getState().getData();
-        org.bukkit.material.Dispenser disp = (org.bukkit.material.Dispenser) d;
+        org.bukkit.material.Dispenser disp = (org.bukkit.material.Dispenser) dis.getData();
         BlockFace face = disp.getFacing();
-        TNTPrimed a = (TNTPrimed) dis.getWorld().spawnEntity(dis.getBlock().getRelative(face).getLocation(),
-                EntityType.PRIMED_TNT);
+        Location location = dis.getBlock().getRelative(face).getLocation().add(0.5, 0.5, 0.5);
+        TNTPrimed a = (TNTPrimed) dis.getWorld().spawnEntity(location, EntityType.PRIMED_TNT);
         a.setVelocity(velocity);
         a.setIsIncendiary(true);
         a.setYield(0.4f);

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/Fan.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/Fan.java
@@ -1,6 +1,7 @@
 package com.sk89q.craftbook.mech.dispenser;
 
 import com.sk89q.worldedit.blocks.BlockID;
+import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Entity;
@@ -33,11 +34,12 @@ public class Fan extends Recipe {
 
         MaterialData d = dis.getBlock().getState().getData();
         BlockFace face = ((org.bukkit.material.Dispenser) d).getFacing();
-        for (Entity e : dis.getWorld().getChunkAt(dis.getBlock().getRelative(face).getLocation()).getEntities())
-            if (e.getLocation().getBlock().getLocation().distanceSquared(dis.getBlock().getRelative(face).getLocation
-                    ()) <= 2 * 2) {
+        Location dispenserLoc = dis.getBlock().getRelative(face).getLocation().add(0.5, 0.5, 0.5);
+        for (Entity e : dis.getWorld().getChunkAt(dispenserLoc).getEntities()) {
+            if (e.getLocation().distanceSquared(dispenserLoc) <= 2 * 2) {
                 e.setVelocity(e.getVelocity().add(velocity).multiply(10));
             }
+        }
         return true;
     }
 }

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/FireArrows.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/FireArrows.java
@@ -2,6 +2,7 @@ package com.sk89q.craftbook.mech.dispenser;
 
 import com.sk89q.worldedit.blocks.BlockID;
 import com.sk89q.worldedit.blocks.ItemID;
+import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Arrow;
@@ -32,10 +33,10 @@ public class FireArrows extends Recipe {
     @Override
     public boolean doAction(Dispenser dis, ItemStack item, Vector velocity, BlockDispenseEvent event) {
 
-        MaterialData d = dis.getBlock().getState().getData();
-        org.bukkit.material.Dispenser disp = (org.bukkit.material.Dispenser) d;
+        org.bukkit.material.Dispenser disp = (org.bukkit.material.Dispenser) dis.getData();
         BlockFace face = disp.getFacing();
-        Arrow a = dis.getWorld().spawnArrow(dis.getBlock().getRelative(face).getLocation(), velocity, 1.0f, 0.0f);
+        Location location = dis.getBlock().getRelative(face).getLocation().add(0.5, 0.5, 0.5);
+        Arrow a = dis.getWorld().spawnArrow(location, velocity, 1.0f, 0.0f);
         a.setFireTicks(5000);
         return true;
     }

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/Recipe.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/Recipe.java
@@ -5,12 +5,14 @@ import org.bukkit.event.block.BlockDispenseEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
+import java.util.Arrays;
+
 /**
  * @author Me4502
  */
-public class Recipe {
+public abstract class Recipe {
 
-    final int[] recipe;
+    private final int[] recipe;
 
     public Recipe(int[] recipe) {
 
@@ -20,13 +22,34 @@ public class Recipe {
     /**
      * Does the recipe action.
      *
-     * @param velocity
-     * @param event
+     * @param dis the dispenser firing the item
+     * @param item the original item to be fired
+     * @param velocity the velocity the item is to be fired at
+     * @param event the BlockDispenseEvent
      *
      * @return true if event needs to be cancelled.
      */
-    public boolean doAction(Dispenser dis, ItemStack item, Vector velocity, BlockDispenseEvent event) {
+    public abstract boolean doAction(Dispenser dis, ItemStack item, Vector velocity, BlockDispenseEvent event);
 
-        return false;
+    /**
+     * Gets the contents of this recipe as a 9-element array representing the 3x3 dispenser grid.
+     * @return the recipe contents
+     */
+    public int[] getRecipe() {
+        return recipe;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Recipe)) return false;
+
+        return Arrays.equals(recipe, ((Recipe) o).recipe);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(recipe);
     }
 }

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/SnowShooter.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/SnowShooter.java
@@ -29,7 +29,7 @@ public class SnowShooter extends Recipe {
     @Override
     public boolean doAction(Dispenser dis, ItemStack item, Vector velocity, BlockDispenseEvent event) {
 
-        event.setItem(new ItemStack(332, 1));
+        event.setItem(new ItemStack(ItemID.SNOWBALL, 1));
         return true;
     }
 }

--- a/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/XPShooter.java
+++ b/mechanisms/src/main/java/com/sk89q/craftbook/mech/dispenser/XPShooter.java
@@ -29,7 +29,7 @@ public class XPShooter extends Recipe {
     @Override
     public boolean doAction(Dispenser dis, ItemStack item, Vector velocity, BlockDispenseEvent event) {
 
-        event.setItem(new ItemStack(384, 1));
+        event.setItem(new ItemStack(ItemID.BOTTLE_O_ENCHANTING, 1));
         return true;
     }
 }


### PR DESCRIPTION
- Print stack trace on failed think/unload for mechanics, to aid debugging
- Fixed some formatting
- Removed redundant Math.round() in XPStorer, changed setTotalExperience
  to setExp as the former didn't appear to work
- "else if" for comparing mutually exclusive conditions
- Fixed fire arrows "misfiring" from dispensers
- Weakened field access in DispenserRecipes
- Cleaned up dispenser recipe parsing logic
- Fixed some javadoc
- Added .equals() to Recipe taking into account recipe items only
  (which means that any recipe with exactly the same items is
  considered a duplicate, regardless of action)
- Replaced some "magic number" item IDs with the relevant ItemID constant
