### PR TITLE
Fixed Redstone not updating around source block

### DIFF
--- a/src/main/java/com/sk89q/craftbook/util/ICUtil.java
+++ b/src/main/java/com/sk89q/craftbook/util/ICUtil.java
@@ -81,9 +81,14 @@ public class ICUtil {
             // set the new data
             block.setData((byte) newData, true);
             // apply physics to the source block the lever is attached to
-            block.setData(block.getData(), true);
-            BlockRedstoneEvent event = new BlockRedstoneEvent(block,wasOn ? 15 : 0, state ? 15 : 0);
-            CraftBookPlugin.inst().getServer().getPluginManager().callEvent(event);
+            source.setData((byte)newData, true);
+
+            // lets call blockredstone events on the source block and the lever
+            // in order to correctly update all surrounding blocks
+            BlockRedstoneEvent leverEvent = new BlockRedstoneEvent(block, wasOn ? 15 : 0, state ? 15 : 0);
+            BlockRedstoneEvent sourceEvent = new BlockRedstoneEvent(source, wasOn ? 15 : 0, state ? 15 : 0);
+            CraftBookPlugin.inst().getServer().getPluginManager().callEvent(leverEvent);
+            CraftBookPlugin.inst().getServer().getPluginManager().callEvent(sourceEvent);
             return true;
         }
 


### PR DESCRIPTION
Hi,

when @me4502 removed the NMS code he also removed the update code for the source block.

And yay bukkit now updates the blocks correctly using the physics event, so I added an event to update the source block.

Should fix some problems with redstone :)
