### PR TITLE
fix door/bridge IC not working when only two coordinates are used

### DIFF
--- a/src/main/java/com/sk89q/craftbook/circuits/gates/world/blocks/SetBridge.java
+++ b/src/main/java/com/sk89q/craftbook/circuits/gates/world/blocks/SetBridge.java
@@ -1,9 +1,5 @@
 package com.sk89q.craftbook.circuits.gates.world.blocks;
 
-import org.bukkit.Server;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-
 import com.sk89q.craftbook.ChangedSign;
 import com.sk89q.craftbook.bukkit.util.BukkitUtil;
 import com.sk89q.craftbook.circuits.ic.AbstractIC;
@@ -12,9 +8,13 @@ import com.sk89q.craftbook.circuits.ic.ChipState;
 import com.sk89q.craftbook.circuits.ic.IC;
 import com.sk89q.craftbook.circuits.ic.ICFactory;
 import com.sk89q.craftbook.circuits.ic.RestrictedIC;
+import com.sk89q.craftbook.util.BlockUtil;
 import com.sk89q.craftbook.util.LocationUtil;
 import com.sk89q.craftbook.util.RegexUtil;
 import com.sk89q.craftbook.util.SignUtil;
+import org.bukkit.Server;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 
 /**
  * @author Silthus
@@ -147,9 +147,14 @@ public class SetBridge extends AbstractIC {
         for (int x = 0; x < width; x++) {
             for (int z = 0; z < depth; z++) {
                 Block block = LocationUtil.getRelativeOffset(center, faceing, x, 0, z);
+                // do not replace the block the sign is on
+                boolean isSource = block.equals(getBackBlock());
+
                 if (open) {
+                    if (isSource && !BlockUtil.isBlockSolid(onMaterial)) continue;
                     block.setTypeIdAndData(onMaterial, (byte) onData, true);
                 } else {
+                    if (isSource && !BlockUtil.isBlockSolid(offMaterial)) continue;
                     block.setTypeIdAndData(offMaterial, (byte) offData, true);
                 }
             }

--- a/src/main/java/com/sk89q/craftbook/circuits/gates/world/blocks/SetDoor.java
+++ b/src/main/java/com/sk89q/craftbook/circuits/gates/world/blocks/SetDoor.java
@@ -1,5 +1,6 @@
 package com.sk89q.craftbook.circuits.gates.world.blocks;
 
+import com.sk89q.craftbook.util.BlockUtil;
 import org.bukkit.Server;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -146,9 +147,14 @@ public class SetDoor extends AbstractIC {
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 Block block = LocationUtil.getRelativeOffset(center, faceing, x, y, 0);
+                // do not replace the block the sign is on
+                boolean isSource = block.equals(getBackBlock());
+
                 if (open) {
+                    if (isSource && !BlockUtil.isBlockSolid(onMaterial)) continue;
                     block.setTypeIdAndData(onMaterial, (byte) onData, true);
                 } else {
+                    if (isSource && !BlockUtil.isBlockSolid(offMaterial)) continue;
                     block.setTypeIdAndData(offMaterial, (byte) offData, true);
                 }
             }

--- a/src/main/java/com/sk89q/craftbook/util/BlockUtil.java
+++ b/src/main/java/com/sk89q/craftbook/util/BlockUtil.java
@@ -1,5 +1,6 @@
 package com.sk89q.craftbook.util;
 
+import com.sk89q.worldedit.blocks.BlockID;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 
@@ -30,6 +31,26 @@ public class BlockUtil {
     public static void setBlockTypeAndData(Block block, int type, byte data) {
 
         block.setTypeIdAndData(type, data, true);
+    }
+
+    public static boolean isBlockSolid(int id) {
+
+        switch (id) {
+
+            case BlockID.AIR:
+            case BlockID.CROPS:
+            case BlockID.DEAD_BUSH:
+            case BlockID.END_PORTAL:
+            case BlockID.FIRE:
+            case BlockID.GRASS:
+            case BlockID.LAVA:
+            case BlockID.STATIONARY_LAVA:
+            case BlockID.WATER:
+            case BlockID.STATIONARY_WATER:
+                return false;
+            default:
+                return true;
+        }
     }
 
     public static Location getBlockCentre(Block block) {


### PR DESCRIPTION
When people are only using two offsets like it was the case in falsebook (x and y) the bridge will fuck up and set all three coordinates to default instead of using the already set coordinates and only using the one default coordinate.

Example:

[MC1211]
10-0
-1,5:6,4

Current: Will default to 0,1,0 but should be -1,5,0.
