### PR TITLE
Fix exception when creating blank/invalid TimeSet sign mc1232

### DIFF
--- a/src/main/java/com/sk89q/craftbook/circuits/gates/world/weather/TimeSet.java
+++ b/src/main/java/com/sk89q/craftbook/circuits/gates/world/weather/TimeSet.java
@@ -33,7 +33,11 @@ public class TimeSet extends AbstractSelfTriggeredIC {
     @Override
     public void load() {
 
-        time = Long.parseLong(getSign().getLine(2));
+        try {
+            time = Long.parseLong(getSign().getLine(2));
+        } catch (NumberFormatException ex) {
+            time = -1;
+        }
     }
 
     /* it's been a */ long time;
@@ -42,7 +46,7 @@ public class TimeSet extends AbstractSelfTriggeredIC {
     public void trigger(ChipState chip) {
 
         try {
-            if (chip.getInput(0)) {
+            if (chip.getInput(0) && time >= 0) {
                 BukkitUtil.toSign(getSign()).getWorld().setTime(time);
             }
         } catch (Exception ignored) {
@@ -53,8 +57,8 @@ public class TimeSet extends AbstractSelfTriggeredIC {
     public void think(ChipState chip) {
 
         try {
-            if (chip.getInput(0)) {
-                BukkitUtil.toSign(getSign()).getWorld().setTime(Long.parseLong(getSign().getLine(2)));
+            if (chip.getInput(0) && time >= 0) {
+                BukkitUtil.toSign(getSign()).getWorld().setTime(time);
             }
         } catch (Exception ignored) {
         }
@@ -87,7 +91,7 @@ public class TimeSet extends AbstractSelfTriggeredIC {
     }
 
     @Override
-    public boolean isActive () {
+    public boolean isActive() {
         return true;
     }
 }


### PR DESCRIPTION
Since that last one was kind of non-constructive, here's a real one: Creating a blank mc1232 causes an exception on create and break.

Attempted fix, please tell me if changing the "think" method to refer to its state was valid or not because I didn't really look too far into it, and it seems weird that it should be different in the original. --edit-- and I don't see how self-triggered time set works either.
