### PR TITLE
Add world name to ST mechanic section of the report

### DIFF
--- a/src/main/java/com/sk89q/craftbook/bukkit/ReportWriter.java
+++ b/src/main/java/com/sk89q/craftbook/bukkit/ReportWriter.java
@@ -181,7 +181,8 @@ public class ReportWriter {
 
             for(SelfTriggeringMechanic mech : plugin.getManager().thinkingMechanics) {
                 if(mech instanceof ICMechanic) {
-                    log.put((ICMechanic) mech).getIC().getSign().getLocalWorld() + ': ' ((ICMechanic) mech).getIC().getSign().getBlockVector().toString(), "%s", ((ICMechanic) mech).getIC().getSign().getLine(0) + "|" +
+                    log.put((ICMechanic) mech).getIC().getSign().getLocalWorld() + ': ' + 
+                            ((ICMechanic) mech).getIC().getSign().getBlockVector().toString(), "%s", ((ICMechanic) mech).getIC().getSign().getLine(0) + "|" +
                             ((ICMechanic) mech).getIC().getSign().getLine(1) + "|" + ((ICMechanic) mech).getIC().getSign().getLine(2) + "|" +
                             ((ICMechanic) mech).getIC().getSign().getLine(3));
                 }


### PR DESCRIPTION
Should change this example:
(-168.0, 65.0, -12503.0) : RECEIVER|[MC1111]S|gatein|
to this:
WorldName: (-168.0, 65.0, -12503.0) : RECEIVER|[MC1111]S|gatein|
