### PR TITLE
'/cb update' improvements for when an update is found.

### DIFF
--- a/src/main/java/com/sk89q/craftbook/bukkit/commands/TopLevelCommands.java
+++ b/src/main/java/com/sk89q/craftbook/bukkit/commands/TopLevelCommands.java
@@ -82,6 +82,11 @@ public class TopLevelCommands {
                 Updater updater = new Updater(CraftBookPlugin.inst(), CraftBookPlugin.getUpdaterID(), CraftBookPlugin.inst().getFile(), Updater.UpdateType.DEFAULT, true);
                 if(updater.getResult() == UpdateResult.NO_UPDATE)
                     sender.sendMessage("No updates are available!");
+                else
+                {
+                    sender.sendMessage("Update Found! Check console for install progress.");
+                    CraftBookPlugin.inst().checkForUpdates();
+                }
             }
         }
 


### PR DESCRIPTION
When an update is found and an install is started by '/cb update,' The user should receive a message telling them the install was started in the console and they should check there for details.

More importantly, the plugin should re-run the checkForUpdates() command so that if an update install DID occur, it does not continue to warn ops of the available update when they login even though they already installed it.
