### PR TITLE
Implementation of the disable method in ICMechanic

### DIFF
--- a/src/main/java/com/sk89q/craftbook/circuits/ic/ICMechanic.java
+++ b/src/main/java/com/sk89q/craftbook/circuits/ic/ICMechanic.java
@@ -70,6 +70,12 @@ public class ICMechanic extends AbstractCraftBookMechanic {
         this.manager = manager;
     }
 
+    @Override
+    public void disable() {
+        
+        this.manager.disable();
+    }
+    
     public Object[] setupIC(Block block, boolean create) {
 
         // if we're not looking at a wall sign, it can't be an IC.


### PR DESCRIPTION
Due to the absence of the method the persistent data of the ICs aren't
stored (I think to the Wireless Transmitter).
So this implementation call the disable method in the ICManager class.
