### PR TITLE
Add setting to completely disable self-triggered ICs

### DIFF
--- a/src/main/java/com/sk89q/craftbook/bukkit/CraftBookPlugin.java
+++ b/src/main/java/com/sk89q/craftbook/bukkit/CraftBookPlugin.java
@@ -582,7 +582,7 @@ public class CraftBookPlugin extends JavaPlugin {
                     continue;
                 }
                 getServer().getPluginManager().registerEvents(mech, this);
-                if(mech instanceof CookingPot || mech instanceof ICMechanic) //TODO make this a better check.
+                if(mech instanceof CookingPot || (mech instanceof ICMechanic && !((ICMechanic) mech).disableSelfTriggered)) //TODO make this a better check.
                     hasSTMechanic = true;
                 if(mech instanceof CartBlockMechanism)
                     useLegacyCartSystem = true;

--- a/src/main/java/com/sk89q/craftbook/mechanics/ic/ICMechanic.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/ic/ICMechanic.java
@@ -186,8 +186,11 @@ public class ICMechanic extends AbstractCraftBookMechanic {
         }
 
         // okay, everything checked out. we can finally make it.
-        if (ic instanceof SelfTriggeredIC && (sign.getLine(1).trim().toUpperCase(Locale.ENGLISH).endsWith("S") || ((SelfTriggeredIC) ic).isAlwaysST()))
+        if (ic instanceof SelfTriggeredIC && (sign.getLine(1).trim().toUpperCase(Locale.ENGLISH).endsWith("S") || ((SelfTriggeredIC) ic).isAlwaysST())) {
+            if (disableSelfTriggered)
+                return null;
             CraftBookPlugin.inst().getSelfTriggerManager().registerSelfTrigger(block.getLocation());
+        }
 
         Object[] rets = new Object[3];
         rets[0] = id;
@@ -457,8 +460,13 @@ public class ICMechanic extends AbstractCraftBookMechanic {
 
                 sign.update(false);
 
-                if (ic instanceof SelfTriggeredIC && (event.getLine(1).trim().toUpperCase(Locale.ENGLISH).endsWith("S") || ((SelfTriggeredIC) ic).isAlwaysST()))
+                if (ic instanceof SelfTriggeredIC && (event.getLine(1).trim().toUpperCase(Locale.ENGLISH).endsWith("S") || ((SelfTriggeredIC) ic).isAlwaysST())) {
+                    if (disableSelfTriggered) {
+                        player.printError("Self-triggered ICs are disabled!");
+                        return;
+                    }
                     CraftBookPlugin.inst().getSelfTriggerManager().registerSelfTrigger(block.getLocation());
+                }
 
                 player.print("You've created " + registration.getId() + ": " + ic.getTitle() + ".");
             });
@@ -535,6 +543,7 @@ public class ICMechanic extends AbstractCraftBookMechanic {
     public boolean savePersistentData;
     public boolean usePercussionMidi;
     public boolean breakOnError;
+    public boolean disableSelfTriggered;
 
     @Override
     public void loadConfiguration (YAMLProcessor config, String path) {
@@ -565,5 +574,8 @@ public class ICMechanic extends AbstractCraftBookMechanic {
 
         config.setComment(path + "break-on-error", "Break the IC sign when an error occurs from that specific IC.");
         breakOnError = config.getBoolean(path + "break-on-error", false);
+        
+        config.setComment(path + "disable-self-triggered", "Disable creation and checking of self-triggered ICs.");
+        disableSelfTriggered = config.getBoolean(path + "disable-self-triggered", false);
     }
 }

--- a/src/main/resources/mechanisms.yml
+++ b/src/main/resources/mechanisms.yml
@@ -181,6 +181,7 @@ mechanics:
         save-persistent-data: true
         midi-use-percussion: false
         break-on-error: false
+        disable-self-triggered: false
     LegacyCauldron:
         block: STONE
     LightStone:


### PR DESCRIPTION
This adds a config option (`mechanics.ICs.disable-self-triggered`) with which all self-triggered ICs can be completely disabled. This does not only prevent the creation of new self-triggered ICs but also stops the manager from ticking the ICs.