### PR TITLE
Fix player language functionality

### DIFF
--- a/src/main/java/com/sk89q/craftbook/core/LanguageManager.java
+++ b/src/main/java/com/sk89q/craftbook/core/LanguageManager.java
@@ -56,16 +56,16 @@ public class LanguageManager {
 
             lang.save();
 
-            languageMap.put(language, lang);
+            languageMap.put(language.toLowerCase(), lang);
         }
     }
 
     public String getString(String message, String language) {
 
         //message = ChatColor.stripColor(message);
-        if(language == null || !languageMap.containsKey(language))
+        if(language == null || !languageMap.containsKey(language.toLowerCase()))
             language = CraftBookPlugin.inst().getConfiguration().language;
-        YAMLProcessor languageData = languageMap.get(language);
+        YAMLProcessor languageData = languageMap.get(language.toLowerCase());
         String def = defaultMessages.get(message);
         if(languageData == null) {
             if(!CraftBookPlugin.inst().getConfiguration().languageScanText || def != null) {
@@ -103,14 +103,7 @@ public class LanguageManager {
     }
 
     public static String getPlayersLanguage(Player p) {
-
-        //try {
-        //Field d = EntityPlayer.class.getDeclaredField("locale");
-        //d.setAccessible(true);
-        //return (String) d.get(((CraftPlayer) p).getHandle());
-        //} catch (Throwable e) {
-        return CraftBookPlugin.inst().getConfiguration().language;
-        //}
+        return p.getLocale();
     }
 
     public Set<String> getLanguages() {


### PR DESCRIPTION
This re-adds the ability to have the plugin select the message file depending on the language that the player has selected in his client as Bukkit now as an API for it.

Because Minecraft seems to send [lowercase language strings](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Player.html#getLocale--) to the server I just completely ignored the case of the language names by storing and querying everything lowercase. This shouldn't create conflicts with any language definitions as they are unique even when case is ignored as far as I am aware of.