### PR TITLE
Fix chair height

### DIFF
--- a/craftbook-sponge/src/main/java/com/sk89q/craftbook/sponge/mechanics/Chairs.java
+++ b/craftbook-sponge/src/main/java/com/sk89q/craftbook/sponge/mechanics/Chairs.java
@@ -163,7 +163,7 @@ public class Chairs extends SpongeBlockMechanic implements DocumentationProvider
     }
 
     private void addChair(Player player, Location<World> location) {
-        Entity entity = location.getExtent().createEntity(EntityTypes.ARMOR_STAND, location.getBlockPosition().toDouble().sub(-0.5, 1, -0.5));
+        Entity entity = location.getExtent().createEntity(EntityTypes.ARMOR_STAND, location.getBlockPosition().toDouble().sub(-0.5, 1.2, -0.5));
         entity.offer(Keys.INVISIBLE, true);
         entity.offer(Keys.HAS_GRAVITY, false);
 


### PR DESCRIPTION
Sitting height in a chair was changed (moved down by 0.2 blocks) to be more like other chair plugins for Bukkit and/or Spigot.
Insignificant change of code, somewhat significant change of player experience (regarding reports from a number of "testers" of this change on my server).