### PR TITLE
Add event for ranged collectors that has item entity

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/ic/gates/world/items/RangedCollector.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/ic/gates/world/items/RangedCollector.java
@@ -8,7 +8,7 @@ import com.sk89q.craftbook.mechanics.ic.AbstractSelfTriggeredIC;
 import com.sk89q.craftbook.mechanics.ic.ChipState;
 import com.sk89q.craftbook.mechanics.ic.IC;
 import com.sk89q.craftbook.mechanics.ic.ICFactory;
-import com.sk89q.craftbook.mechanics.pipe.PipeRequestEvent;
+import com.sk89q.craftbook.mechanics.ranged.RangedCollectEvent;
 import com.sk89q.craftbook.util.ICUtil;
 import com.sk89q.craftbook.util.InventoryUtil;
 import com.sk89q.craftbook.util.ItemSyntax;
@@ -136,7 +136,7 @@ public class RangedCollector extends AbstractSelfTriggeredIC {
                 BlockFace back = SignUtil.getBack(CraftBookBukkitUtil.toSign(getSign()).getBlock());
                 Block pipe = getBackBlock().getRelative(back);
 
-                PipeRequestEvent event = new PipeRequestEvent(pipe, new ArrayList<>(Collections.singletonList(stack)), getBackBlock());
+                RangedCollectEvent event = new RangedCollectEvent(pipe, (Item) entity, new ArrayList<>(Collections.singletonList(stack)), getBackBlock());
                 Bukkit.getPluginManager().callEvent(event);
 
                 if (event.isCancelled()) {

--- a/src/main/java/com/sk89q/craftbook/mechanics/ranged/RangedCollectEvent.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/ranged/RangedCollectEvent.java
@@ -1,0 +1,21 @@
+package com.sk89q.craftbook.mechanics.ranged;
+
+import com.sk89q.craftbook.mechanics.pipe.PipeRequestEvent;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+public class RangedCollectEvent extends PipeRequestEvent {
+    private final Item item;
+
+    public RangedCollectEvent(Block theBlock, Item item, List<ItemStack> itemstacks, Block sucked) {
+        super(theBlock, itemstacks, sucked);
+        this.item = item;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+}


### PR DESCRIPTION
This event will allow plugins to listen to when a ranged collector picks up an item from the world, while keeping the item entity exposed.

I am using this to protect item entities on top of shop chests from being collected by ranged collectors.