### PR TITLE
Fix hiddenswitch issues for 1.15

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/HiddenSwitch.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/HiddenSwitch.java
@@ -1,13 +1,13 @@
 package com.sk89q.craftbook.mechanics;
 
-import com.sk89q.craftbook.CraftBookPlayer;
-import com.sk89q.craftbook.bukkit.util.CraftBookBukkitUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Powerable;
+import org.bukkit.block.data.type.Switch;
 import org.bukkit.block.data.type.WallSign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -20,7 +20,9 @@ import org.bukkit.inventory.ItemStack;
 
 import com.sk89q.craftbook.AbstractCraftBookMechanic;
 import com.sk89q.craftbook.ChangedSign;
+import com.sk89q.craftbook.CraftBookPlayer;
 import com.sk89q.craftbook.bukkit.CraftBookPlugin;
+import com.sk89q.craftbook.bukkit.util.CraftBookBukkitUtil;
 import com.sk89q.craftbook.util.EventUtil;
 import com.sk89q.craftbook.util.ItemSyntax;
 import com.sk89q.craftbook.util.ItemUtil;
@@ -98,12 +100,12 @@ public class HiddenSwitch extends AbstractCraftBookMechanic {
             boolean success = false;
 
             if (!ItemUtil.isStackValid(itemID)) {
-                toggleSwitches(testBlock, eventFace.getOppositeFace());
+                toggleSwitches(testBlock);
                 success = true;
             } else {
                 if (ItemUtil.areItemsIdentical(player.getInventory().getItemInMainHand(), itemID)
                         || ItemUtil.areItemsIdentical(player.getInventory().getItemInOffHand(), itemID)) {
-                    toggleSwitches(testBlock, eventFace.getOppositeFace());
+                    toggleSwitches(testBlock);
                     success = true;
                 } else
                     lplayer.printError("mech.hiddenswitch.key");
@@ -149,13 +151,12 @@ public class HiddenSwitch extends AbstractCraftBookMechanic {
             event.setCancelled(true);
     }
 
-    private static void toggleSwitches(Block sign, BlockFace direction) {
-
+    private static void toggleSwitches(Block sign) {
         BlockFace[] checkFaces = new BlockFace[4];
         checkFaces[0] = BlockFace.UP;
         checkFaces[1] = BlockFace.DOWN;
 
-        switch (direction) {
+        switch (((WallSign) sign.getBlockData()).getFacing()) {
             case EAST:
             case WEST:
                 checkFaces[2] = BlockFace.NORTH;
@@ -174,15 +175,39 @@ public class HiddenSwitch extends AbstractCraftBookMechanic {
                 Powerable powerable = (Powerable) checkBlock.getBlockData();
                 powerable.setPowered(!powerable.isPowered());
                 checkBlock.setBlockData(powerable);
+
+                Switch lever = (Switch) checkBlock.getBlockData();
+                Block attachedBlock = checkBlock.getRelative(lever.getFacing().getOppositeFace());
+                forceUpdate(attachedBlock);
             } else if (Tag.BUTTONS.getValues().contains(checkBlock.getType())) {
                 Powerable powerable = (Powerable) checkBlock.getBlockData();
                 powerable.setPowered(true);
                 checkBlock.setBlockData(powerable);
-                powerable.setPowered(false);
-                Runnable turnOff = () -> checkBlock.setBlockData(powerable);
+
+                Switch button = (Switch) checkBlock.getBlockData();
+                Block attachedBlock = checkBlock.getRelative(button.getFacing().getOppositeFace());
+                forceUpdate(attachedBlock);
+
+                Runnable turnOff = () -> turnOffButton(checkBlock, attachedBlock, powerable);
                 Bukkit.getScheduler().runTaskLater(CraftBookPlugin.inst(), turnOff, Tag.WOODEN_BUTTONS.getValues().contains(checkBlock.getType()) ? 30L : 20L);
             }
         }
+    }
+
+    private static void turnOffButton(Block buttonBlock, Block attachedBlock, Powerable powerable) {
+        powerable.setPowered(false);
+        buttonBlock.setBlockData(powerable);
+        forceUpdate(attachedBlock);
+    }
+
+    private static void forceUpdate(Block attachedBlock) {
+        // Workaround for spigot not properly updating redstone. Changing the
+        // block material and then immediately changing it back forces a full
+        // update to surrounding redstone. The placeholder material is never
+        // visible.
+        BlockData attachedBlockData = attachedBlock.getBlockData();
+        attachedBlock.setType(attachedBlock.getType() == Material.DIRT ? Material.STONE : Material.DIRT, false);
+        attachedBlock.setBlockData(attachedBlockData, true);
     }
 
     private boolean anyside;


### PR DESCRIPTION
This PR addresses two issues with Hidden Switches. Please refer to (or construct) the following:

![image](https://user-images.githubusercontent.com/4888254/90338264-13571880-dfae-11ea-9ed7-560ef52f90c8.png)

### Issue 1

Problem: The behavior of the levers is different depending on which side of the red block (with the sign) you click. If you click on the front (with the sign) or back (opposite the sign), all 3 levers flip and all 3 redstone lamps toggle. However if you click on the left side of the red block, then only the levers on the white and yellow blocks flip -- the lever on the green block doesn't flip nor does the redstone lamp next to the green block's lever toggle.

Analysis: The search for surrounding levers is based on the face of the block clicked, not the location of the sign.

Solution: I updated `toggleSwitches` to search around the orientation of the sign, not the face that was clicked.

### Issue 2

Problem: Redstone surrounding the lever or button does not update. Clicking the red block toggles the lever on the green block but this does not toggle the redstone torch. Whereas, if you click the lever directly it does toggle the redstone torch. This behavior is also seen with other components (I tested redstone wire and repeaters but I suspect it applies generally).

Analysis: Since 1.13, `myBlock.setBlockData(myBlock.getBlockData(), true)` does not force an update of the surrounding redstone.

Solution: To force an update, I implemented a workaround that momentarily swaps the block material, which does cause an update to the surrounding redstone. While this is admittedly a hack, I have not experienced any problems with it. The placeholder block (dirt or stone) never appears, and these placeholders don't have interesting behavior. You can swap the levers for buttons in the sample structure for confirmation.

Note: I also tried the approach in [ICUtil.java](https://github.com/EngineHub/CraftBook/blob/0129b03008cb22b724d6b30db7aeeca0b5bee77e/src/main/java/com/sk89q/craftbook/util/ICUtil.java#L81-L95) for this but that didn't work either.