### PR TITLE
Add link in crafting-recipes.yml

### DIFF
--- a/src/main/resources/defaults/crafting-recipes.yml
+++ b/src/main/resources/defaults/crafting-recipes.yml
@@ -1,6 +1,6 @@
 # CraftBook Custom Recipes. CraftBook Version: Demo Copy
 # For more information on setting up custom recipes, see the wiki:
-# http://wiki.sk89q.com/wiki/CraftBook/Custom_crafting
+# https://craftbook.enginehub.org/en/5.0.0/mechanics/custom_crafting
 
 crafting-recipes:
   shapelessexample:


### PR DESCRIPTION
Add link in line 3

from - http://wiki.sk89q.com/wiki/CraftBook/Usage

to - https://craftbook.enginehub.org/en/5.0.0/mechanics/custom_crafting

Note !
Missing page custom_crafting by using 
https://craftbook.enginehub.org/en/latest/mechanics/