### PR TITLE
Do not store XP into bottles if another plugin cancels the event

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/XPStorer.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/XPStorer.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public class XPStorer extends AbstractCraftBookMechanic {
 
-    @EventHandler
+    @EventHandler (ignoreCancelled = true)
     public void onRightClick(PlayerInteractEvent event) {
 
         if(event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_AIR) return;


### PR DESCRIPTION
Solves the problem described in title.