### PR TITLE
Make sure to remove perm/op after command

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/crafting/CustomCrafting.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/crafting/CustomCrafting.java
@@ -364,10 +364,15 @@ public class CustomCrafting extends AbstractCraftBookMechanic {
                     PermissionAttachment att = p.addAttachment(CraftBookPlugin.inst());
                     att.setPermission("*", true);
                     boolean wasOp = p.isOp();
-                    p.setOp(true);
-                    Bukkit.dispatchCommand(p, s);
-                    att.remove();
-                    p.setOp(wasOp);
+                    if (!wasOp)
+                        p.setOp(true);
+                    try {
+                        Bukkit.dispatchCommand(p, s);
+                    } finally {
+                        att.remove();
+                        if (!wasOp)
+                            p.setOp(false);
+                    }
                 }
             }
         }

--- a/src/main/java/com/sk89q/craftbook/mechanics/items/CommandItems.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/items/CommandItems.java
@@ -552,14 +552,17 @@ public class CommandItems extends AbstractCraftBookMechanic {
             boolean wasOp = player.isOp();
             if(!wasOp)
                 player.setOp(true);
-            if (comdef.fakeCommand) {
-                ProtectionUtil.canSendCommand(player, command);
-            } else {
-                Bukkit.dispatchCommand(player, command);
+            try {
+                if (comdef.fakeCommand) {
+                    ProtectionUtil.canSendCommand(player, command);
+                } else {
+                    Bukkit.dispatchCommand(player, command);
+                }
+            } finally {
+                att.remove();
+                if(!wasOp)
+                    player.setOp(false);
             }
-            att.remove();
-            if(!wasOp)
-                player.setOp(wasOp);
         }
     }
 


### PR DESCRIPTION
This change makes sure that the wildcard permission and op status are properly removed from the player after the command in the command items or custom crafting configs are executed even if any kind of exception occurred while executing it.

Also adjusted the CustomCrafting op setters to work the same way as the CommandItems ones (checking the `wasOp`) and explicitly setting the op to `false` after execution to improve code readability.