### PR TITLE
Fix compile error introduced in #1284

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/Elevator.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/Elevator.java
@@ -346,7 +346,7 @@ public class Elevator extends AbstractCraftBookMechanic {
                 foundGround = true;
                 break;
             }
-            if (floor.getY() == clickedBlock.getWorld().getMinHeight()) {
+            if (floor.getY() == destination.getWorld().getMinHeight()) {
                 break;
             }
             floor = floor.getRelative(BlockFace.DOWN);


### PR DESCRIPTION
Found an instance where the wrong variable was used. In this context the variable is 'destination' not 'clickedBlock'

With this change I've been able to successfully compile the build on my system.