### PR TITLE
Try not to enable legacy material compatibility layer

### DIFF
--- a/src/main/java/com/sk89q/craftbook/util/BlockSyntax.java
+++ b/src/main/java/com/sk89q/craftbook/util/BlockSyntax.java
@@ -39,6 +39,8 @@ public class BlockSyntax {
 
     private static Set<String> knownBadLines = new HashSet<>();
 
+    private static boolean matchLegacyMaterials = false;
+
     static {
         BLOCK_CONTEXT.setPreferringWildcard(true);
         BLOCK_CONTEXT.setRestricted(false);
@@ -63,7 +65,10 @@ public class BlockSyntax {
 
         if (blockState == null) {
             String[] dataSplit = RegexUtil.COLON_PATTERN.split(line.replace("\\:", ":"), 2);
-            Material material = Material.getMaterial(dataSplit[0], true);
+            Material material = Material.getMaterial(dataSplit[0], matchLegacyMaterials);
+            if (material == null && !matchLegacyMaterials) {
+                material = Material.getMaterial(dataSplit[0], matchLegacyMaterials = true);
+            }
             if (material != null) {
                 int data = 0;
                 if (dataSplit.length > 1) {


### PR DESCRIPTION
### What this change does
This change tries to match a material without engaging spigot's legacy material compatibility layer. If a match is not found, then it tries with legacy support. Once legacy support has been tried once it is assumed all materials will be legacy so it will continue to use legacy support in order to prevent double checks on every single material. (i hope that makes sense)

### Why this change is wanted
When spigot's legacy material compatibility layer engages, it adds all the legacy materials to the material enum which causes all material actions and lookups to be _a little bit_ slower until the server is rebooted. (plus, we all like to see the [smiley face on paper's bstats page](https://bstats.org/plugin/server-implementation/Paper/580#legacy_plugins))