### PR TITLE
PipePutEvent now supports additional, custom predicates

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipeFilterEvent.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipeFilterEvent.java
@@ -1,0 +1,51 @@
+package com.sk89q.craftbook.mechanics.pipe;
+
+import org.bukkit.block.Block;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+
+public class PipeFilterEvent extends PipeEvent {
+
+  private static final HandlerList handlers = new HandlerList();
+
+  private boolean beenSet = false;
+
+  public PipeFilterEvent(Block theBlock, List<ItemStack> items) {
+    super(theBlock, items);
+  }
+
+  @Override
+  public void setItems(List<ItemStack> items) {
+    super.setItems(items);
+    this.beenSet = true;
+  }
+
+  @Override
+  public List<ItemStack> getItems() {
+    return Collections.unmodifiableList(super.getItems());
+  }
+
+  @Override
+  public void addItems(List<ItemStack> items) {
+    throw new UnsupportedOperationException();
+  }
+
+  public boolean hasBeenSet() {
+    return this.beenSet;
+  }
+
+  @Override
+  @Nonnull
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  @Nonnull
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+}

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipeFilterEvent.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipeFilterEvent.java
@@ -12,24 +12,24 @@ public class PipeFilterEvent extends PipeEvent {
 
     private static final HandlerList handlers = new HandlerList();
 
-    private Set<ItemStack> filters;
-    private Set<ItemStack> exceptions;
+    private Set<ItemStack> includeFilters;
+    private Set<ItemStack> excludeFilters;
     private List<ItemStack> filteredItems;
 
-    public PipeFilterEvent(Block theBlock, List<ItemStack> items, Set<ItemStack> filters, Set<ItemStack> exceptions, List<ItemStack> filteredItems) {
+    public PipeFilterEvent(Block theBlock, List<ItemStack> items, Set<ItemStack> includeFilters, Set<ItemStack> excludeFilters, List<ItemStack> filteredItems) {
         super(theBlock, items);
 
-        this.filters = filters;
-        this.exceptions = exceptions;
+        this.includeFilters = includeFilters;
+        this.excludeFilters = excludeFilters;
         this.filteredItems = filteredItems;
     }
 
-    public Set<ItemStack> getFilters() {
-        return filters;
+    public Set<ItemStack> getIncludeFilters() {
+        return includeFilters;
     }
 
-    public Set<ItemStack> getExceptions() {
-        return exceptions;
+    public Set<ItemStack> getExcludeFilters() {
+        return excludeFilters;
     }
 
     public List<ItemStack> getFilteredItems() {

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipeFilterEvent.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipeFilterEvent.java
@@ -10,44 +10,44 @@ import java.util.Set;
 
 public class PipeFilterEvent extends PipeEvent {
 
-  private static final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
 
-  private Set<ItemStack> filters;
-  private Set<ItemStack> exceptions;
-  private List<ItemStack> filteredItems;
+    private Set<ItemStack> filters;
+    private Set<ItemStack> exceptions;
+    private List<ItemStack> filteredItems;
 
-  public PipeFilterEvent(Block theBlock, List<ItemStack> items, Set<ItemStack> filters, Set<ItemStack> exceptions, List<ItemStack> filteredItems) {
-    super(theBlock, items);
+    public PipeFilterEvent(Block theBlock, List<ItemStack> items, Set<ItemStack> filters, Set<ItemStack> exceptions, List<ItemStack> filteredItems) {
+        super(theBlock, items);
 
-    this.filters = filters;
-    this.exceptions = exceptions;
-    this.filteredItems = filteredItems;
-  }
+        this.filters = filters;
+        this.exceptions = exceptions;
+        this.filteredItems = filteredItems;
+    }
 
-  public Set<ItemStack> getFilters() {
-    return filters;
-  }
+    public Set<ItemStack> getFilters() {
+        return filters;
+    }
 
-  public Set<ItemStack> getExceptions() {
-    return exceptions;
-  }
+    public Set<ItemStack> getExceptions() {
+        return exceptions;
+    }
 
-  public List<ItemStack> getFilteredItems() {
-    return filteredItems;
-  }
+    public List<ItemStack> getFilteredItems() {
+        return filteredItems;
+    }
 
-  public void setFilteredItems(List<ItemStack> filteredItems) {
-    this.filteredItems = filteredItems;
-  }
+    public void setFilteredItems(List<ItemStack> filteredItems) {
+        this.filteredItems = filteredItems;
+    }
 
-  @Override
-  @Nonnull
-  public HandlerList getHandlers() {
-    return handlers;
-  }
+    @Override
+    @Nonnull
+    public HandlerList getHandlers() {
+        return handlers;
+    }
 
-  @Nonnull
-  public static HandlerList getHandlerList() {
-    return handlers;
-  }
+    @Nonnull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipeFilterEvent.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipeFilterEvent.java
@@ -5,37 +5,39 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class PipeFilterEvent extends PipeEvent {
 
   private static final HandlerList handlers = new HandlerList();
 
-  private boolean beenSet = false;
+  private Set<ItemStack> filters;
+  private Set<ItemStack> exceptions;
+  private List<ItemStack> filteredItems;
 
-  public PipeFilterEvent(Block theBlock, List<ItemStack> items) {
+  public PipeFilterEvent(Block theBlock, List<ItemStack> items, Set<ItemStack> filters, Set<ItemStack> exceptions, List<ItemStack> filteredItems) {
     super(theBlock, items);
+
+    this.filters = filters;
+    this.exceptions = exceptions;
+    this.filteredItems = filteredItems;
   }
 
-  @Override
-  public void setItems(List<ItemStack> items) {
-    super.setItems(items);
-    this.beenSet = true;
+  public Set<ItemStack> getFilters() {
+    return filters;
   }
 
-  @Override
-  public List<ItemStack> getItems() {
-    return Collections.unmodifiableList(super.getItems());
+  public Set<ItemStack> getExceptions() {
+    return exceptions;
   }
 
-  @Override
-  public void addItems(List<ItemStack> items) {
-    throw new UnsupportedOperationException();
+  public List<ItemStack> getFilteredItems() {
+    return filteredItems;
   }
 
-  public boolean hasBeenSet() {
-    return this.beenSet;
+  public void setFilteredItems(List<ItemStack> filteredItems) {
+    this.filteredItems = filteredItems;
   }
 
   @Override

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipePutEvent.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipePutEvent.java
@@ -5,21 +5,15 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
 
 public class PipePutEvent extends PipeEvent implements Cancellable {
 
     private Block put;
-    private List<ItemStack> rejectedItems;
 
     public PipePutEvent (Block theBlock, List<ItemStack> items, Block put) {
         super(theBlock, items);
         this.put = put;
-        this.rejectedItems = new ArrayList<>();
     }
 
     @Override
@@ -52,21 +46,5 @@ public class PipePutEvent extends PipeEvent implements Cancellable {
 
     public boolean isValid() {
         return !isCancelled && !getItems().isEmpty();
-    }
-
-    public void applyCustomPredicate(Predicate<ItemStack> predicate) {
-        for (Iterator<ItemStack> itemIterator = getItems().iterator(); itemIterator.hasNext();) {
-            ItemStack item = itemIterator.next();
-
-            if (predicate.test(item))
-                continue;
-
-            itemIterator.remove();
-            rejectedItems.add(item);
-        }
-    }
-
-    public List<ItemStack> getRejectedItems() {
-        return Collections.unmodifiableList(this.rejectedItems);
     }
 }

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipePutEvent.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/PipePutEvent.java
@@ -5,15 +5,21 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 public class PipePutEvent extends PipeEvent implements Cancellable {
 
     private Block put;
+    private List<ItemStack> rejectedItems;
 
     public PipePutEvent (Block theBlock, List<ItemStack> items, Block put) {
         super(theBlock, items);
         this.put = put;
+        this.rejectedItems = new ArrayList<>();
     }
 
     @Override
@@ -46,5 +52,21 @@ public class PipePutEvent extends PipeEvent implements Cancellable {
 
     public boolean isValid() {
         return !isCancelled && !getItems().isEmpty();
+    }
+
+    public void applyCustomPredicate(Predicate<ItemStack> predicate) {
+        for (Iterator<ItemStack> itemIterator = getItems().iterator(); itemIterator.hasNext();) {
+            ItemStack item = itemIterator.next();
+
+            if (predicate.test(item))
+                continue;
+
+            itemIterator.remove();
+            rejectedItems.add(item);
+        }
+    }
+
+    public List<ItemStack> getRejectedItems() {
+        return Collections.unmodifiableList(this.rejectedItems);
     }
 }

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
@@ -138,24 +138,33 @@ public class Pipes extends AbstractCraftBookMechanic {
             if (bl.getType() == Material.PISTON) {
                 Piston p = (Piston) bl.getBlockData();
 
-                ChangedSign sign = getSignOnPiston(bl);
+                List<ItemStack> filteredItems;
 
-                HashSet<ItemStack> pFilters = new HashSet<>();
-                HashSet<ItemStack> pExceptions = new HashSet<>();
+                PipeFilterEvent filterEvent = new PipeFilterEvent(bl, items);
+                Bukkit.getPluginManager().callEvent(filterEvent);
 
-                if(sign != null) {
-                    for(String line3 : RegexUtil.COMMA_PATTERN.split(sign.getLine(2))) {
-                        pFilters.add(ItemSyntax.getItem(line3.trim()));
+                if (filterEvent.hasBeenSet()) {
+                    filteredItems = filterEvent.getItems();
+                } else {
+                    ChangedSign sign = getSignOnPiston(bl);
+
+                    HashSet<ItemStack> pFilters = new HashSet<>();
+                    HashSet<ItemStack> pExceptions = new HashSet<>();
+
+                    if (sign != null) {
+                        for (String line3 : RegexUtil.COMMA_PATTERN.split(sign.getLine(2))) {
+                            pFilters.add(ItemSyntax.getItem(line3.trim()));
+                        }
+                        for (String line4 : RegexUtil.COMMA_PATTERN.split(sign.getLine(3))) {
+                            pExceptions.add(ItemSyntax.getItem(line4.trim()));
+                        }
+
+                        pFilters.removeAll(Collections.<ItemStack>singleton(null));
+                        pExceptions.removeAll(Collections.<ItemStack>singleton(null));
                     }
-                    for(String line4 : RegexUtil.COMMA_PATTERN.split(sign.getLine(3))) {
-                        pExceptions.add(ItemSyntax.getItem(line4.trim()));
-                    }
 
-                    pFilters.removeAll(Collections.<ItemStack>singleton(null));
-                    pExceptions.removeAll(Collections.<ItemStack>singleton(null));
+                    filteredItems = new ArrayList<>(VerifyUtil.withoutNulls(ItemUtil.filterItems(items, pFilters, pExceptions)));
                 }
-
-                List<ItemStack> filteredItems = new ArrayList<>(VerifyUtil.withoutNulls(ItemUtil.filterItems(items, pFilters, pExceptions)));
 
                 if(filteredItems.isEmpty())
                     continue;
@@ -192,7 +201,6 @@ public class Pipes extends AbstractCraftBookMechanic {
 
                     items.removeAll(filteredItems);
                     items.addAll(newItems);
-                    items.addAll(event.getRejectedItems());
                 }
             } else if (bl.getType() == Material.DROPPER) {
                 ChangedSign sign = getSignOnPiston(bl);

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
@@ -192,6 +192,7 @@ public class Pipes extends AbstractCraftBookMechanic {
 
                     items.removeAll(filteredItems);
                     items.addAll(newItems);
+                    items.addAll(event.getRejectedItems());
                 }
             } else if (bl.getType() == Material.DROPPER) {
                 ChangedSign sign = getSignOnPiston(bl);

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
@@ -138,33 +138,29 @@ public class Pipes extends AbstractCraftBookMechanic {
             if (bl.getType() == Material.PISTON) {
                 Piston p = (Piston) bl.getBlockData();
 
-                List<ItemStack> filteredItems;
+                ChangedSign sign = getSignOnPiston(bl);
 
-                PipeFilterEvent filterEvent = new PipeFilterEvent(bl, items);
-                Bukkit.getPluginManager().callEvent(filterEvent);
+                HashSet<ItemStack> pFilters = new HashSet<>();
+                HashSet<ItemStack> pExceptions = new HashSet<>();
 
-                if (filterEvent.hasBeenSet()) {
-                    filteredItems = filterEvent.getItems();
-                } else {
-                    ChangedSign sign = getSignOnPiston(bl);
-
-                    HashSet<ItemStack> pFilters = new HashSet<>();
-                    HashSet<ItemStack> pExceptions = new HashSet<>();
-
-                    if (sign != null) {
-                        for (String line3 : RegexUtil.COMMA_PATTERN.split(sign.getLine(2))) {
-                            pFilters.add(ItemSyntax.getItem(line3.trim()));
-                        }
-                        for (String line4 : RegexUtil.COMMA_PATTERN.split(sign.getLine(3))) {
-                            pExceptions.add(ItemSyntax.getItem(line4.trim()));
-                        }
-
-                        pFilters.removeAll(Collections.<ItemStack>singleton(null));
-                        pExceptions.removeAll(Collections.<ItemStack>singleton(null));
+                if(sign != null) {
+                    for(String line3 : RegexUtil.COMMA_PATTERN.split(sign.getLine(2))) {
+                        pFilters.add(ItemSyntax.getItem(line3.trim()));
+                    }
+                    for(String line4 : RegexUtil.COMMA_PATTERN.split(sign.getLine(3))) {
+                        pExceptions.add(ItemSyntax.getItem(line4.trim()));
                     }
 
-                    filteredItems = new ArrayList<>(VerifyUtil.withoutNulls(ItemUtil.filterItems(items, pFilters, pExceptions)));
+                    pFilters.removeAll(Collections.<ItemStack>singleton(null));
+                    pExceptions.removeAll(Collections.<ItemStack>singleton(null));
                 }
+
+                List<ItemStack> filteredItems = new ArrayList<>(VerifyUtil.withoutNulls(ItemUtil.filterItems(items, pFilters, pExceptions)));
+
+                PipeFilterEvent filterEvent = new PipeFilterEvent(bl, items, pFilters, pExceptions, filteredItems);
+                Bukkit.getPluginManager().callEvent(filterEvent);
+
+                filteredItems = filterEvent.getFilteredItems();
 
                 if(filteredItems.isEmpty())
                     continue;


### PR DESCRIPTION
I would love to execute additional, custom and rather nuanced filters, which are stored on the `[Pipe]`-sign's `PersistentDataContainer` and are later parsed into an AST. All that's missing to get my desired functionality implemented is to reject items without removing them from the pipe-walk algorithm. I do not want to drop them, I simply want them to move on, as with native filters.

This rather simple and concise commit allows just that: executing a custom predicate while keeping rejected items in the system, without any measurable overhead. It would mean a lot to me if my change was to be merged, so that I can provide my feature to a small server who would most definitely decline it if they had to build from source.