### PR TITLE
Pipe support for `crafter`, `decorated_pot` and `chiseled_bookshelf`

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
@@ -357,6 +357,9 @@ public class Pipes extends AbstractCraftBookMechanic {
                     || fac.getType() == Material.DISPENSER
                     || fac.getType() == Material.HOPPER
                     || fac.getType() == Material.BARREL
+                    || fac.getType() == Material.CHISELED_BOOKSHELF
+                    || fac.getType() == Material.CRAFTER
+                    || fac.getType() == Material.DECORATED_POT
                     || Tag.SHULKER_BOXES.isTagged(fac.getType())) {
                 for (ItemStack stack : ((InventoryHolder) fac.getState()).getInventory().getContents()) {
 

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
@@ -29,6 +29,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.Dropper;
 import org.bukkit.block.Furnace;
 import org.bukkit.block.Jukebox;
+import org.bukkit.block.Crafter;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.type.Piston;
@@ -385,9 +386,13 @@ public class Pipes extends AbstractCraftBookMechanic {
                 }
 
                 if (!items.isEmpty()) {
-                    for (ItemStack item : items) {
-                        if (item == null) continue;
-                        leftovers.addAll(((InventoryHolder) fac.getState()).getInventory().addItem(item).values());
+                    if (fac.getType() == Material.CRAFTER)
+                        leftovers.addAll(InventoryUtil.addItemsToCrafter((Crafter) fac.getState(), items.toArray(new ItemStack[items.size()])));
+                    else {
+                        for (ItemStack item : items) {
+                            if (item == null) continue;
+                            leftovers.addAll(((InventoryHolder) fac.getState()).getInventory().addItem(item).values());
+                        }
                     }
                 }
             } else if (fac.getType() == Material.FURNACE || fac.getType() == Material.BLAST_FURNACE || fac.getType() == Material.SMOKER) {

--- a/src/main/java/com/sk89q/craftbook/util/ItemUtil.java
+++ b/src/main/java/com/sk89q/craftbook/util/ItemUtil.java
@@ -797,6 +797,26 @@ public final class ItemUtil {
         }
     }
 
+    /**
+     * Checks whether an item can be put in a chiseled bookshelf.
+     * 
+     * @param item The item to check.
+     * @return If the item can be put in a chiseled bookshelf.
+     */
+    public static boolean isAStorableBook(ItemStack item) {
+
+        switch(item.getType()) {
+            case BOOK:
+            case WRITABLE_BOOK:
+            case WRITTEN_BOOK:
+            case ENCHANTED_BOOK:
+            case KNOWLEDGE_BOOK:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     public static boolean containsRawFood(Inventory inv) {
 
         return getRawFood(inv).size() > 0;


### PR DESCRIPTION
The changes add support for:
- `crafter`, `decorated_pot` as pipe input and output
- `chiseled_bookshelf` as pipe input

and fix pipes trying to put non book items into `chiseled_bookshelfs` which caused their deletion.

When puting items into a `crafter` the pipe also respects the disabled slots.