### PR TITLE
Make cactus flowers harvestable

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/ic/gates/world/blocks/CombineHarvester.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/ic/gates/world/blocks/CombineHarvester.java
@@ -86,6 +86,8 @@ public class CombineHarvester extends AbstractSelfTriggeredIC {
             case COCOA:
                 Ageable ageable = (Ageable) block.getBlockData();
                 return ageable.getAge() == ageable.getMaximumAge();
+            case CACTUS_FLOWER:
+                return below == Material.CACTUS;
             case CACTUS:
                 return below == Material.CACTUS && above != Material.CACTUS;
             case SUGAR_CANE:


### PR DESCRIPTION
Since Minecraft 1.21.5 cacti grow flowers with a 10% chance instead of adding another cactus block on top.
This leads to cacti no longer being harvestable by the combine harvester after a while.

Making the flowers harvestable seems to be the logical solution to this problem and has been working perfectly on 1.21.8 for some time now.