### PR TITLE
Fix the map changer

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/MapChanger.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/MapChanger.java
@@ -62,8 +62,10 @@ public class MapChanger extends AbstractCraftBookMechanic {
         }
 
         ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
-        if (item == null || (item.getType() != Material.MAP && item.getType() != Material.FILLED_MAP)) 
+        if (item == null 
+            || (item.getType() != Material.MAP && item.getType() != Material.FILLED_MAP)) {
             return;
+        }
 
         final int mapId;
         try {


### PR DESCRIPTION
Fix the map changer to work with bigger map id's and not throw an exception on blank maps. This also seems to fix filling out already filled maps since I believe the material type was changed in 1.13+. Basically everything about this seemed to be non-functional on modern versions.

It was throwing `java.lang.ClassCastException: class org.bukkit.craftbukkit.inventory.CraftMetaItem cannot be cast to class org.bukkit.inventory.meta.MapMeta)` on Material.MAP because it doesn't have MapMeta, and wasn't even attempting to update Material.FILLED_MAP.