### PR TITLE
Fix three jukebox item bugs in pipes

### DIFF
--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
@@ -182,14 +182,21 @@ public class Pipes extends AbstractCraftBookMechanic {
                     } else if (fac.getType() == Material.JUKEBOX) {
                         Jukebox juke = (Jukebox) fac.getState();
                         List<ItemStack> its = new ArrayList<>(event.getItems());
-                        if (juke.getPlaying() != Material.AIR) {
+                        // Only an empty jukebox accepts a disc. The test was inverted, so
+                        // an empty jukebox never took one, and a playing one had its disc
+                        // overwritten by setPlaying and destroyed. Discs that do not fit
+                        // stay in the list and flow on through the pipe.
+                        if (juke.getPlaying() == Material.AIR) {
                             Iterator<ItemStack> iter = its.iterator();
                             while (iter.hasNext()) {
                                 ItemStack st = iter.next();
                                 if (!st.getType().isRecord()) continue;
                                 juke.setPlaying(st.getType());
                                 juke.update();
-                                iter.remove();
+                                if (st.getAmount() > 1)
+                                    st.setAmount(st.getAmount() - 1);
+                                else
+                                    iter.remove();
                                 break;
                             }
                         }

--- a/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
+++ b/src/main/java/com/sk89q/craftbook/mechanics/pipe/Pipes.java
@@ -429,28 +429,30 @@ public class Pipes extends AbstractCraftBookMechanic {
                 Jukebox juke = (Jukebox) fac.getState();
 
                 if (juke.getPlaying() != Material.AIR) {
+                    // Remove the disc before firing the event. Inferring "the disc left
+                    // the jukebox" from the item list afterwards duplicated the disc
+                    // whenever delivery was refused: a copy dropped at the piston while
+                    // the original kept playing.
                     items.add(new ItemStack(juke.getPlaying()));
+                    juke.setPlaying(Material.AIR);
+                    juke.update();
+                }
 
+                if (!items.isEmpty()) {
                     PipeSuckEvent event = new PipeSuckEvent(block, new ArrayList<>(items), fac);
                     Bukkit.getPluginManager().callEvent(event);
                     items.clear();
                     items.addAll(event.getItems());
 
-                    if (!event.isCancelled()) {
+                    if (!event.isCancelled() && !items.isEmpty()) {
                         visitedPipes.add(fac.getLocation().toVector());
                         searchNearbyPipes(block, visitedPipes, items);
                     }
-
-                    if (!items.isEmpty()) {
-                        for (ItemStack item : items) {
-                            if (!ItemUtil.isStackValid(item)) continue;
-                            block.getWorld().dropItem(BlockUtil.getBlockCentre(block), item);
-                        }
-                    } else {
-                        juke.setPlaying(Material.AIR);
-                        juke.update();
-                    }
                 }
+                // Route undelivered items through leftovers like the other branches;
+                // this was the only branch that never fed it, so an empty jukebox
+                // destroyed any items a request delivered into it.
+                leftovers.addAll(items);
             } else {
                 PipeSuckEvent event = new PipeSuckEvent(block, new ArrayList<>(items), fac);
                 Bukkit.getPluginManager().callEvent(event);


### PR DESCRIPTION
Three separate bugs in how Pipes handles jukeboxes, all reproducible on a test server.

**1. Disc duplication (suck path).** The branch creates a new disc ItemStack and only empties the jukebox if every item was delivered. If the network is full or missing, the copy drops at the piston while the original keeps playing. A clocked sticky piston facing a playing jukebox prints discs.

Repro: jukebox with a disc playing, sticky piston facing it, no pipe network. Pulse the piston. A disc drops and the jukebox keeps playing. Repeat for more discs.

**2. Item loss (suck path).** It is the only branch that never feeds leftovers, so when the jukebox is empty, any items a pipe request delivers into it are cleared at the end of startPipe and destroyed.

**3. Item loss (put path).** The insert test is inverted: a disc is only inserted when the jukebox is already playing, so an empty jukebox never accepts one. When it does fire, setPlaying overwrites the playing disc and destroys it.

Repro: chest with a disc, pipe into a jukebox that is already playing a different disc. Two discs before, one after.

**Fixes.** For the suck path, take the disc out of the jukebox before firing the event and route undelivered items through leftovers like the other branches. For the put path, only insert into an empty jukebox and let discs that do not fit flow on through the pipe.

One behavior change worth noting: a disc the network refuses now drops at the piston instead of staying in the jukebox. That is what stops the duplication.